### PR TITLE
Support -DD to skip byte comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Usage: fdupes [options] DIRECTORY...
                          particular directory more than once; refer to the
                          fdupes documentation for additional information
 -D --deferconfirmation  in interactive mode, defer byte-for-byte confirmation
-                        of duplicates until just before file deletion
+                        of duplicates until just before file deletion;
+                        specify twice (-DD) to skip confirmation entirely
 -e --heuristic         use heuristic hashing for large files
 -P --plain              with --delete, use line-based prompt (as with older
                          versions of fdupes) instead of screen-mode interface

--- a/fdupes.1
+++ b/fdupes.1
@@ -101,7 +101,8 @@ below).
 .TP
 .B -D --deferconfirmation
 In interactive mode, defer byte-for-byte confirmation of
-duplicates until just before file deletion.
+duplicates until just before file deletion.  Specify the
+option twice to skip byte-for-byte confirmation entirely.
 .TP
 .B -e --heuristic
 Use heuristic hashing for files larger than 3MB, hashing the first and last

--- a/fdupes.c
+++ b/fdupes.c
@@ -1248,7 +1248,7 @@ void deletefiles(file_t *files, int prompt, FILE *tty, char *logfile)
             log_file_remaining(loginfo, dupelist[x]->d_name);
         }
 	else {
-    if (ISFLAG(flags, F_DEFERCONFIRMATION))
+    if (ISFLAG(flags, F_DEFERCONFIRMATION) && !ISFLAG(flags, F_NOCONFIRMATION))
     {
       firstpreserved = 0;
       for (i = 1; i <= counter; ++i)
@@ -1559,7 +1559,8 @@ void help_text()
   printf("                         particular directory more than once; refer to the\n");
   printf("                         fdupes documentation for additional information\n");
   printf(" -D --deferconfirmation  in interactive mode, defer byte-for-byte confirmation\n");
-  printf("                         of duplicates until just before file deletion\n");
+  printf("                         of duplicates until just before file deletion;\n");
+  printf("                         specify twice to skip confirmation entirely\n");
   printf(" -e --heuristic         use heuristic hashing for large files\n");
 #ifndef NO_NCURSES
   printf(" -P --plain              with --delete, use line-based prompt (as with older\n");
@@ -1780,7 +1781,10 @@ int main(int argc, char **argv) {
       logfile = optarg;
       break;
     case 'D':
-      SETFLAG(flags, F_DEFERCONFIRMATION);
+      if (ISFLAG(flags, F_DEFERCONFIRMATION))
+        SETFLAG(flags, F_NOCONFIRMATION);
+      else
+        SETFLAG(flags, F_DEFERCONFIRMATION);
       break;
     case 'e':
       SETFLAG(flags, F_HEURISTIC);

--- a/flags.h
+++ b/flags.h
@@ -30,6 +30,7 @@
 #define F_VACUUMCACHE       0x800000
 #define F_QUICKSUMMARY     0x1000000
 #define F_HEURISTIC        0x2000000
+#define F_NOCONFIRMATION   0x4000000
 
 extern unsigned long flags;
 

--- a/ncurses-commands.c
+++ b/ncurses-commands.c
@@ -770,7 +770,7 @@ int cmd_prune(struct filegroup *groups, int groupcount, wchar_t *commandargument
       {
         if (groups[g].files[f].action == FILEACTION_DELETE)
         {
-          if (ISFLAG(flags, F_DEFERCONFIRMATION))
+          if (ISFLAG(flags, F_DEFERCONFIRMATION) && !ISFLAG(flags, F_NOCONFIRMATION))
           {
             format_status_left(status, L"Confirming duplicates...");
             print_status(statuswin, status);


### PR DESCRIPTION
## Summary
- add `F_NOCONFIRMATION` flag
- allow specifying `-D` twice to skip byte-wise confirmation
- update interactive delete logic to honor new flag
- document new behaviour in README and manpage

## Testing
- `gcc -c fdupes.c` *(fails: `config.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686a71c82ae8832bae14e3208896bad0