### PR TITLE
Fix missing function prototype causing build error

### DIFF
--- a/fdupes.c
+++ b/fdupes.c
@@ -512,6 +512,8 @@ md5_byte_t *getcrcsignatureuntil(char *filename, off_t fsize, off_t max_read)
   return digest;
 }
 
+md5_byte_t *getheuristicsignature(char *filename, off_t fsize);
+
 md5_byte_t *getcrcsignature(char *filename, off_t fsize)
 {
   if (ISFLAG(flags, F_HEURISTIC) && fsize > HEURISTIC_LIMIT)


### PR DESCRIPTION
## Summary
- declare `getheuristicsignature` before use in `getcrcsignature`

## Testing
- `make` *(fails: No makefile found)*
- `gcc -c fdupes.c` *(fails: config.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a7c04b570832b95ab38acc2432981